### PR TITLE
Make the session timeout relative to last activity

### DIFF
--- a/src/GDS/Session/Handler.php
+++ b/src/GDS/Session/Handler.php
@@ -104,6 +104,8 @@ class Handler implements \SessionHandlerInterface
             [$obj_handler, 'gc']
         );
         session_start();
+        // Reset the session cookie lifetime to be from now rather than the session creation
+        setcookie(session_name(), session_id(), time() + $int_duration);
     }
 
     /**


### PR DESCRIPTION
Pretty simple change really, every time the session is started this change recalculated the session lifetime and resets the cookie expiry for it to prevent sessions dying randomly.